### PR TITLE
Issue 22: Downgrade org.clojure/clojurescript to 1.10.597

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules
 .cpcache
 index.js*
 tests.js
-.cljs_node_repl

--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,3 @@
-{:deps {org.clojure/clojurescript {:mvn/version "1.10.773"}
+{:deps {org.clojure/clojurescript {:mvn/version "1.10.597"}
         com.cognitect/transit-cljs {:mvn/version "0.8.256"}
         cljs-http/cljs-http {:mvn/version "0.1.46"}}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-force-resolutions",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This addresses the regression seen in version `0.0.4` listed as Issue https://github.com/rogeriochaves/npm-force-resolutions/issues/22

I've tested versions of `org.clojure/clojurescript` back from current, `1.10.597` was the latest non-regressing version
https://mvnrepository.com/artifact/org.clojure/clojurescript

@rogeriochaves 