### PR TITLE
Sort packages in package-lock.json after applying updates

### DIFF
--- a/src/npm_force_resolutions/core.cljs
+++ b/src/npm_force_resolutions/core.cljs
@@ -152,7 +152,8 @@
     (let [package-lock (read-json (str folder "/package-lock.json"))
           resolutions (<! (find-resolutions folder))]
       (->> (patch-all-dependencies resolutions package-lock)
-          (sort-or-remove-map "dependencies")))))
+          (sort-or-remove-map "dependencies")
+          (sort-or-remove-map "packages"))))
 
 (defn indent-json [json]
   (let [json-format (nodejs/require "json-format")]


### PR DESCRIPTION
When there is a special constellation npm stops working with the package-lock.json produced by npm-force-resolutions (for example `ERR_REQUIRE_ESM`). In order to work around this issue and be compliant with the generated package-lock.json, the packages node inside the JSON shall be sorted.

This fixes issue #57 